### PR TITLE
fix off-by-one error in loadImage.js

### DIFF
--- a/js/loadImage.js
+++ b/js/loadImage.js
@@ -17,7 +17,7 @@ var loadImages = function(dataPath, groupName, pictureName){
 			imgLen = [imagesFileNames count];
 
 		for(var i = 0; i < imgAmount; i++){
-			var r = Math.ceil(Math.random() * imgLen);
+			var r = Math.floor(Math.random() * imgLen);
 			var fileName = imagesPath+imagesFileNames[r];
 			if ([fileManager fileExistsAtPath: fileName]) {				
 				var newImage = [[NSImage alloc] initWithContentsOfFile:fileName];			


### PR DESCRIPTION
Sometimes loadImages goes one over the number of available images, throws an exception, and dies.

Statistically unlikely to happen given that the plugin ships with 100-1000+ images for each persona; I noticed this issue after I replaced one of those image sets with a smaller one of my own and the plugin appeared to stop working.
