### PR TITLE
Change import statements to be CocoaScript compliant

### DIFF
--- a/Geo/France/City.sketchplugin
+++ b/Geo/France/City.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/geo/france/cities.json'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/geo/france/cities.json'
 
 loadText(data);

--- a/Geo/France/City.sketchplugin
+++ b/Geo/France/City.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/geo/france/cities.json'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/geo/france/cities.json'
 
 loadText(data);

--- a/Geo/France/Department.sketchplugin
+++ b/Geo/France/Department.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/geo/france/departments.json'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/geo/france/departments.json'
 
 loadText(data);

--- a/Geo/France/Department.sketchplugin
+++ b/Geo/France/Department.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/geo/france/departments.json'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/geo/france/departments.json'
 
 loadText(data);

--- a/Geo/France/Region.sketchplugin
+++ b/Geo/France/Region.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/geo/france/regions.json'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/geo/france/regions.json'
 
 loadText(data);

--- a/Geo/France/Region.sketchplugin
+++ b/Geo/France/Region.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/geo/france/regions.json'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/geo/france/regions.json'
 
 loadText(data);

--- a/Geo/Netherlands/City.sketchplugin
+++ b/Geo/Netherlands/City.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/geo/netherlands/cities.json'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/geo/netherlands/cities.json'
 
 loadText(data);

--- a/Geo/Netherlands/City.sketchplugin
+++ b/Geo/Netherlands/City.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/geo/netherlands/cities.json'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/geo/netherlands/cities.json'
 
 loadText(data);

--- a/Geo/Netherlands/Province.sketchplugin
+++ b/Geo/Netherlands/Province.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/geo/netherlands/provinces.json'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/geo/netherlands/provinces.json'
 
 loadText(data);

--- a/Geo/Netherlands/Province.sketchplugin
+++ b/Geo/Netherlands/Province.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/geo/netherlands/provinces.json'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/geo/netherlands/provinces.json'
 
 loadText(data);

--- a/Geo/USA/City.sketchplugin
+++ b/Geo/USA/City.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/geo/usa/cities.json'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/geo/usa/cities.json'
 
 loadText(data);

--- a/Geo/USA/City.sketchplugin
+++ b/Geo/USA/City.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/geo/usa/cities.json'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/geo/usa/cities.json'
 
 loadText(data);

--- a/Geo/USA/Full address.sketchplugin
+++ b/Geo/USA/Full address.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/geo/usa/fulladdress.json'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/geo/usa/fulladdress.json'
 
 loadText(data);

--- a/Geo/USA/Full address.sketchplugin
+++ b/Geo/USA/Full address.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/geo/usa/fulladdress.json'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/geo/usa/fulladdress.json'
 
 loadText(data);

--- a/Geo/USA/States.sketchplugin
+++ b/Geo/USA/States.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/geo/usa/states.json'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/geo/usa/states.json'
 
 loadText(data);

--- a/Geo/USA/States.sketchplugin
+++ b/Geo/USA/States.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/geo/usa/states.json'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/geo/usa/states.json'
 
 loadText(data);

--- a/Persona/Details/Email.sketchplugin
+++ b/Persona/Details/Email.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/persona/emails.js'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/persona/emails.js'
 
 loadText(data, 'email');

--- a/Persona/Details/Email.sketchplugin
+++ b/Persona/Details/Email.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/persona/emails.js'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/persona/emails.js'
 
 loadText(data, 'email');

--- a/Persona/Details/Phone.sketchplugin
+++ b/Persona/Details/Phone.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/persona/phones.js'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/persona/phones.js'
 
 loadText(data, 'phone number');

--- a/Persona/Details/Phone.sketchplugin
+++ b/Persona/Details/Phone.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/persona/phones.js'
+@import '../../js/utility.js'
+@import '../../js/loadText.js'
+@import '../../data/persona/phones.js'
 
 loadText(data, 'phone number');

--- a/Persona/Names/Female & Male.sketchplugin
+++ b/Persona/Names/Female & Male.sketchplugin
@@ -1,6 +1,6 @@
-@import '../js/utility.js'
-@import '../js/loadNames.js'
-@import '../data/names/names.js'
+@import '../../js/utility.js'
+@import '../../js/loadNames.js'
+@import '../../data/names/names.js'
 
 firstNames = data[24][1].concat(data[24][2]);
 lastNames = data[24][3];

--- a/Persona/Names/Female & Male.sketchplugin
+++ b/Persona/Names/Female & Male.sketchplugin
@@ -1,6 +1,6 @@
-#import '../js/utility.js'
-#import '../js/loadNames.js'
-#import '../data/names/names.js'
+@import '../js/utility.js'
+@import '../js/loadNames.js'
+@import '../data/names/names.js'
 
 firstNames = data[24][1].concat(data[24][2]);
 lastNames = data[24][3];

--- a/Persona/Names/Female.sketchplugin
+++ b/Persona/Names/Female.sketchplugin
@@ -1,6 +1,6 @@
-#import '../js/utility.js'
-#import '../js/loadNames.js'
-#import '../data/names/names.js'
+@import '../js/utility.js'
+@import '../js/loadNames.js'
+@import '../data/names/names.js'
 
 firstNames = data[24][2];
 lastNames = data[24][3];

--- a/Persona/Names/Female.sketchplugin
+++ b/Persona/Names/Female.sketchplugin
@@ -1,6 +1,6 @@
-@import '../js/utility.js'
-@import '../js/loadNames.js'
-@import '../data/names/names.js'
+@import '../../js/utility.js'
+@import '../../js/loadNames.js'
+@import '../../data/names/names.js'
 
 firstNames = data[24][2];
 lastNames = data[24][3];

--- a/Persona/Names/Male.sketchplugin
+++ b/Persona/Names/Male.sketchplugin
@@ -1,6 +1,6 @@
-@import '../js/utility.js'
-@import '../js/loadNames.js'
-@import '../data/names/names.js'
+@import '../../js/utility.js'
+@import '../../js/loadNames.js'
+@import '../../data/names/names.js'
 
 firstNames = data[24][1];
 lastNames = data[24][3];

--- a/Persona/Names/Male.sketchplugin
+++ b/Persona/Names/Male.sketchplugin
@@ -1,6 +1,6 @@
-#import '../js/utility.js'
-#import '../js/loadNames.js'
-#import '../data/names/names.js'
+@import '../js/utility.js'
+@import '../js/loadNames.js'
+@import '../data/names/names.js'
 
 firstNames = data[24][1];
 lastNames = data[24][3];

--- a/Persona/Photos/Female.sketchplugin
+++ b/Persona/Photos/Female.sketchplugin
@@ -1,4 +1,4 @@
-#import '../js/utility.js'
-#import '../js/loadImage.js'
+@import '../js/utility.js'
+@import '../js/loadImage.js'
 
 loadImages('data/photos/persona/women/', 'user pic', 'avatar')

--- a/Persona/Photos/Female.sketchplugin
+++ b/Persona/Photos/Female.sketchplugin
@@ -1,4 +1,4 @@
-@import '../js/utility.js'
-@import '../js/loadImage.js'
+@import '../../js/utility.js'
+@import '../../js/loadImage.js'
 
 loadImages('data/photos/persona/women/', 'user pic', 'avatar')

--- a/Persona/Photos/Male.sketchplugin
+++ b/Persona/Photos/Male.sketchplugin
@@ -1,4 +1,4 @@
-@import '../js/utility.js'
-@import '../js/loadImage.js'
+@import '../../js/utility.js'
+@import '../../js/loadImage.js'
 
 loadImages('data/photos/persona/men/', 'user pic', 'avatar')

--- a/Persona/Photos/Male.sketchplugin
+++ b/Persona/Photos/Male.sketchplugin
@@ -1,4 +1,4 @@
-#import '../js/utility.js'
-#import '../js/loadImage.js'
+@import '../js/utility.js'
+@import '../js/loadImage.js'
 
 loadImages('data/photos/persona/men/', 'user pic', 'avatar')

--- a/Persona/Photos/Neutral.sketchplugin
+++ b/Persona/Photos/Neutral.sketchplugin
@@ -1,4 +1,4 @@
-#import '../js/utility.js'
-#import '../js/loadImage.js'
+@import '../js/utility.js'
+@import '../js/loadImage.js'
 
 loadImages('data/photos/persona/neutral/', 'user pic', 'avatar')

--- a/Persona/Photos/Neutral.sketchplugin
+++ b/Persona/Photos/Neutral.sketchplugin
@@ -1,4 +1,4 @@
-@import '../js/utility.js'
-@import '../js/loadImage.js'
+@import '../../js/utility.js'
+@import '../../js/loadImage.js'
 
 loadImages('data/photos/persona/neutral/', 'user pic', 'avatar')

--- a/Photos/Music artist.sketchplugin
+++ b/Photos/Music artist.sketchplugin
@@ -1,4 +1,4 @@
-#import '../js/utility.js'
-#import '../js/loadImage.js'
+@import '../js/utility.js'
+@import '../js/loadImage.js'
 
 loadImages('data/photos/Music/', 'music artist', 'artist photo')

--- a/Photos/Nature and urban.sketchplugin
+++ b/Photos/Nature and urban.sketchplugin
@@ -1,4 +1,4 @@
-#import '../js/utility.js'
-#import '../js/loadImage.js'
+@import '../js/utility.js'
+@import '../js/loadImage.js'
 
 loadImages('data/photos/Landscape/', 'photo', 'photo')

--- a/Text/Dummy text/Fillerati/Generate.sketchplugin
+++ b/Text/Dummy text/Fillerati/Generate.sketchplugin
@@ -1,5 +1,5 @@
-@import 'js/utility.js'
-@import 'js/loadText.js'
-@import 'data/text/fillerati.js'
+@import '../../../js/utility.js'
+@import '../../../js/loadText.js'
+@import '../../../data/text/fillerati.js'
 
 loadText(data, 'fillerati text');

--- a/Text/Dummy text/Fillerati/Generate.sketchplugin
+++ b/Text/Dummy text/Fillerati/Generate.sketchplugin
@@ -1,5 +1,5 @@
-#import 'js/utility.js'
-#import 'js/loadText.js'
-#import 'data/text/fillerati.js'
+@import 'js/utility.js'
+@import 'js/loadText.js'
+@import 'data/text/fillerati.js'
 
 loadText(data, 'fillerati text');

--- a/Text/Dummy text/Fillerati/Replace.sketchplugin
+++ b/Text/Dummy text/Fillerati/Replace.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/replaceTextFitting.js'
-#import '../data/text/fillerati.js'
+@import '../js/utility.js'
+@import '../js/replaceTextFitting.js'
+@import '../data/text/fillerati.js'
 
 loadText(data, 'fillerati text');

--- a/Text/Dummy text/Fillerati/Replace.sketchplugin
+++ b/Text/Dummy text/Fillerati/Replace.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/replaceTextFitting.js'
-@import '../data/text/fillerati.js'
+@import '../../../js/utility.js'
+@import '../../../js/replaceTextFitting.js'
+@import '../../../data/text/fillerati.js'
 
 loadText(data, 'fillerati text');

--- a/Text/Dummy text/Hipsum/Generate.sketchplugin
+++ b/Text/Dummy text/Hipsum/Generate.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/text/hipsum.js'
+@import '../../../js/utility.js'
+@import '../../../js/loadText.js'
+@import '../../../data/text/hipsum.js'
 
 loadText(data, 'hipsum text');

--- a/Text/Dummy text/Hipsum/Generate.sketchplugin
+++ b/Text/Dummy text/Hipsum/Generate.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/text/hipsum.js'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/text/hipsum.js'
 
 loadText(data, 'hipsum text');

--- a/Text/Dummy text/Hipsum/Replace.sketchplugin
+++ b/Text/Dummy text/Hipsum/Replace.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/replaceTextFitting.js'
-@import '../data/text/hipsum.js'
+@import '../../../js/utility.js'
+@import '../../../js/replaceTextFitting.js'
+@import '../../../data/text/hipsum.js'
 
 loadText(data, 'hipsum text');

--- a/Text/Dummy text/Hipsum/Replace.sketchplugin
+++ b/Text/Dummy text/Hipsum/Replace.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/replaceTextFitting.js'
-#import '../data/text/hipsum.js'
+@import '../js/utility.js'
+@import '../js/replaceTextFitting.js'
+@import '../data/text/hipsum.js'
 
 loadText(data, 'hipsum text');

--- a/Text/Dummy text/Lorem/Generate.sketchplugin
+++ b/Text/Dummy text/Lorem/Generate.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/loadText.js'
-#import '../data/text/lorem.js'
+@import '../js/utility.js'
+@import '../js/loadText.js'
+@import '../data/text/lorem.js'
 
 loadText(data, 'lorem text');

--- a/Text/Dummy text/Lorem/Generate.sketchplugin
+++ b/Text/Dummy text/Lorem/Generate.sketchplugin
@@ -1,5 +1,5 @@
-@import '../js/utility.js'
-@import '../js/loadText.js'
-@import '../data/text/lorem.js'
+@import '../../../js/utility.js'
+@import '../../../js/loadText.js'
+@import '../../../data/text/lorem.js'
 
 loadText(data, 'lorem text');

--- a/Text/Dummy text/Lorem/Replace.sketchplugin
+++ b/Text/Dummy text/Lorem/Replace.sketchplugin
@@ -1,5 +1,5 @@
-#import '../js/utility.js'
-#import '../js/replaceTextFitting.js'
-#import '../data/text/lorem.js'
+@import '../js/utility.js'
+@import '../js/replaceTextFitting.js'
+@import '../data/text/lorem.js'
 
 loadText(data, 'lorem text');

--- a/js/utility.js
+++ b/js/utility.js
@@ -25,7 +25,7 @@ var tools = {
 		return normalString;
 	},
 
-	saveFile : function(path,data){		
+	saveFile : function(path,data){
 		var someContent = NSString.stringWithString_(data)
 		var path = path
 		someContent.dataUsingEncoding_(NSUTF8StringEncoding).writeToFile_atomically_(path, true)
@@ -35,7 +35,7 @@ var tools = {
 			var pluginFolder = scriptPath.match(/Plugins\/([\w -])*/)[0] + "/";
 			var sketchPluginsPath = scriptPath.replace(/Plugins([\w \/ -])*.sketchplugin$/, "");
 			return pluginFolder;
-		}		
+		}
 	}
 };
 


### PR DESCRIPTION
Sketch 3.0.2 changed from **JSTalk** to **CocoaScript** which uses `@import` statement instead of `#import`. This pull request fixes the plugin.