### PR TITLE
Fix crash due to `.DS_Store` file + handle less images than selection

### DIFF
--- a/js/loadImage.js
+++ b/js/loadImage.js
@@ -2,33 +2,59 @@ var loadImages = function(dataPath, groupName, pictureName){
 	var groupName = groupName || 'picture';
 		pictureName = pictureName || 'picture';
 
-	function loadImages(imgAmount){
+	function loadImages(selectedImgCount){
+		log('selectedImgCount: '+selectedImgCount);
+
 		var imagesCollection = [],
 			fileManager = [NSFileManager defaultManager];
 
-		if(tools.majorVersion() == 3){			
-			var scriptPath = sketch.scriptPath;			
-			var pluginFolder = scriptPath.match(/Plugins\/([\w -])*/)[0] + "/";
-			var sketchPluginsPath = scriptPath.replace(/Plugins([\w \/ -])*.sketchplugin$/, "");
+		if(tools.majorVersion() == 3){
+			var scriptPath = sketch.scriptPath;
+			var pluginFolder = scriptPath.match(/Plugins\/([\w -])*/)[0] + '/';
+			var sketchPluginsPath = scriptPath.replace(/Plugins([\w \/ -])*.sketchplugin$/, '');
 			imagesPath =  sketchPluginsPath + pluginFolder + dataPath;
-		}	
-		log(imagesPath)
+		}
+		log('imagesPath: '+imagesPath);
 		var imagesFileNames = [fileManager contentsOfDirectoryAtPath:imagesPath error:nil],
 			imgLen = [imagesFileNames count];
 
-		for(var i = 0; i < imgAmount; i++){
-			var r = Math.floor(Math.random() * imgLen);
-			var fileName = imagesPath+imagesFileNames[r];
-			if ([fileManager fileExistsAtPath: fileName]) {				
-				var newImage = [[NSImage alloc] initWithContentsOfFile:fileName];			
+		log('imagesFileNames (before clean): '+imagesFileNames);
+
+		// clean out invalid files
+		var imagesFileNamesCleaned = [];
+		for (var i = 0; i < imgLen; i++) {
+			if (imagesFileNames[i] == '.DS_Store') {
+				log('skipping '+imagesFileNames[i]);
+
+			} else {
+				imagesFileNamesCleaned.push(imagesFileNames[i]);
+			}
+		}
+
+		log('imagesFileNamesCleaned: '+imagesFileNamesCleaned);
+
+		var offset = 0;
+		for (var i = 0; i < selectedImgCount; i++) {
+      var filename = '';
+			if (i+1 > imagesFileNamesCleaned.length) {
+				// no more images (reached end) - move back and use the first ones
+				filename = imagesFileNamesCleaned[offset++];
+			} else {
+				filename = imagesFileNamesCleaned[i];
+			}
+
+			var pathToFile = imagesPath+filename;
+
+			if ([fileManager fileExistsAtPath: pathToFile]) {
+				var newImage = [[NSImage alloc] initWithContentsOfFile:pathToFile];
 				imagesCollection.push(newImage);
 			}
 		}
 
 		return imagesCollection;
-	}
+	};
 
-	function main(){		
+	function main(){
 		var allLayers = [[doc currentPage] layers],
 			imagesCollection = loadImages([selection count]);
 
@@ -37,15 +63,15 @@ var loadImages = function(dataPath, groupName, pictureName){
             if([layer class] == MSShapeGroup){
                 var image = imagesCollection[i];
                 var fill = layer.style().fills().firstObject();
-                fill.setFillType(4);                
-                log(tools.minorVersion())
+                fill.setFillType(4);
+                //log(tools.minorVersion())
                 if(tools.minorVersion() >= 1){
-                	var coll = layer.style().fills().firstObject().documentData().images();              
+                	var coll = layer.style().fills().firstObject().documentData().images();
                 	[fill setPatternImage:image collection:coll]
                 }
                 else{
                 	layer.style().fills().firstObject().setPatternImage( image );
-                }                                                
+                }
                 layer.style().fills().firstObject().setPatternFillType(1);
             }
 		}
@@ -53,5 +79,4 @@ var loadImages = function(dataPath, groupName, pictureName){
 		if([selection count] == 0) alert('Select at least one vector shape');
 	}
 	main();
-}
-
+};


### PR DESCRIPTION
MacOS X generates a meta file `.DS_Store` which will crash Sketch when
attempting to run e.g. `[[NSImage alloc] initWithContentsOfFile:'/path/to/.DS_Store']`.
This fix strips out those filenames. Can probably be done in a cleaner
way but not completely sure what JavaScript syntax Sketch supports.

This fix also adds the ability to use less images (e.g. three images in
"my-photos" directory but five objects in Sketch selection) by simply
starting from the beginning of images again.