### PR TITLE
Added Instagram image generation

### DIFF
--- a/CG.sketchplugin/Contents/Sketch/Images/IG Keywords.js
+++ b/CG.sketchplugin/Contents/Sketch/Images/IG Keywords.js
@@ -1,0 +1,116 @@
+
+// Fill with Picture Of (control command p)
+// Fills selected layers with images tagged from Flickr
+// by Nick Stamas @nickstamas
+
+function onRun(context){
+  var selection = context.selection;
+  var doc = context.document;
+
+  if (selection.length > 0) {
+    var alert = [NSAlert alertWithMessageText: "Fill with pic of:"
+    defaultButton:"OK"
+    alternateButton:"Cancel"
+    otherButton:nil
+    informativeTextWithFormat:""];
+
+    var input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
+    [input setStringValue:"dog"];
+    [input autorelease];
+    [alert setAccessoryView:input];
+    var button = [alert runModal];
+
+    if (button == NSAlertDefaultReturn) {
+      [input validateEditing];
+      var tag = [input stringValue];
+
+      tag = tag.replace(/\s/g, "");
+      log(tag);
+
+      //Gets initial list of data: 18 image responses
+      data = getData(tag);
+
+      if(selection.length > 18) {
+        for (var s = 0; s <= selection.length/18; s++) {
+            //Gets next 18 images
+            var end_cursor = data.tag.media.page_info.end_cursor;
+            data2 = getDataHelper(tag, end_cursor);
+
+            //Adds those images to original image list
+            data.tag.media.nodes = data.tag.media.nodes.concat(data2.tag.media.nodes);
+        }
+      }
+
+      process(selection, data, doc);
+
+    }
+  } else {
+    [doc showMessage:"No layer is selected."];
+  }
+}
+
+function getData(tag) {
+  var request = [[NSMutableURLRequest alloc] init];
+  [request setHTTPMethod:@"GET"];
+  var queryString = "https://www.instagram.com/explore/tags/" + tag + "/?__a=1";
+  [request setURL:[NSURL URLWithString:queryString]];
+
+  var error = [[NSError alloc] init];
+  var responseCode = null;
+
+  var oResponseData = [NSURLConnection sendSynchronousRequest:request returningResponse:responseCode error:error];
+
+  var dataString = [[NSString alloc] initWithData:oResponseData
+  encoding:NSUTF8StringEncoding];
+
+  var pattern = new RegExp("\\\\'", "g");
+  var validJSONString = dataString.replace(pattern, "'");
+
+  return JSON.parse(validJSONString);
+}
+
+function getDataHelper(tag,cursor) {
+  var request = [[NSMutableURLRequest alloc] init];
+  [request setHTTPMethod:@"GET"];
+  var queryString = "https://www.instagram.com/explore/tags/" + tag + "/?__a=1&max_id=" + cursor;
+  [request setURL:[NSURL URLWithString:queryString]];
+
+  var error = [[NSError alloc] init];
+  var responseCode = null;
+
+  var oResponseData = [NSURLConnection sendSynchronousRequest:request returningResponse:responseCode error:error];
+
+  var dataString = [[NSString alloc] initWithData:oResponseData
+  encoding:NSUTF8StringEncoding];
+
+  var pattern = new RegExp("\\\\'", "g");
+  var validJSONString = dataString.replace(pattern, "'");
+
+  return JSON.parse(validJSONString);
+}
+
+function process(selection, data, doc) {
+  if (data.tag.media.nodes.length > 0) {
+    for (var i=0; i < selection.length; i++) {
+
+      var randomIndex = Math.floor(Math.random()*(data.tag.media.nodes.length-1));
+      var imageURLString = data.tag.media.nodes[randomIndex].thumbnail_src;
+
+      var url = [[NSURL alloc] initWithString: imageURLString];
+
+      var newImage = [[NSImage alloc] initByReferencingURL:url];
+
+      var layer = [selection objectAtIndex:i];
+
+      var fill = layer.style().fills().firstObject();
+      fill.setFillType(4);
+
+      fill.setImage(MSImageData.alloc().initWithImage_convertColorSpace(newImage, false));
+      fill.setPatternFillType(1);
+
+    }
+  } else {
+    var message = "No images found tagged with: " + tag;
+    [doc showMessage: message];
+  }
+}

--- a/CG.sketchplugin/Contents/Sketch/manifest.json
+++ b/CG.sketchplugin/Contents/Sketch/manifest.json
@@ -22,6 +22,13 @@
       "identifier" : "flickr"
     },
     {
+      "script" : "Images/Ig Keywords.js",
+      "handler" : "onRun",
+      "shortcut" : "",
+      "name" : "Instagram",
+      "identifier" : "insta"
+    },
+    {
       "script" : "Persona/Photos/Female.js",
       "handler" : "onRun",
       "shortcut" : "",
@@ -265,7 +272,7 @@
       {
         "title": "Images",
         "items": [
-          "custom-images", "flickr", "rad-faces"
+          "custom-images", "flickr", "insta"
         ]
       },
       {


### PR DESCRIPTION
Flickr has a set maximum on providing 20 images through is public feed, so I decided to make something similar using Instagram which can provide more! 

Pros: 
- Higher image limit, so more variety when generating content larger than 20 selections 
- Good for imitating social feeds
Cons: 
- Since it is more of a social feed, pictures won't be as HQ as flickr on average
- Can't search multiple tags, only a single tag (fixable with doing multiple searches and adding the results) 