### PR TITLE
Added version checking for initWithImage_convertColorSpace calls

### DIFF
--- a/CG.sketchplugin/Contents/Sketch/Images/Flickr Keywords.js
+++ b/CG.sketchplugin/Contents/Sketch/Images/Flickr Keywords.js
@@ -57,7 +57,14 @@ function onRun(context){
           var fill = layer.style().fills().firstObject();
           fill.setFillType(4);
 
-          fill.setImage(MSImageData.alloc().initWithImage_convertColorSpace(newImage, false));
+          var imageData;
+          if (MSApplicationMetadata.metadata().appVersion < 47) {
+            imageData = MSImageData.alloc().initWithImage_convertColorSpace(newImage, false);
+          } else {
+            imageData = MSImageData.alloc().initWithImage(newImage);
+          }
+          fill.setImage(imageData);
+
           fill.setPatternFillType(1);
 
         }
@@ -70,4 +77,3 @@ function onRun(context){
     [doc showMessage:"No layer is selected."];
   }
 }
-

--- a/CG.sketchplugin/Contents/Sketch/Images/IG Keywords.js
+++ b/CG.sketchplugin/Contents/Sketch/Images/IG Keywords.js
@@ -105,7 +105,13 @@ function process(selection, data, doc) {
       var fill = layer.style().fills().firstObject();
       fill.setFillType(4);
 
-      fill.setImage(MSImageData.alloc().initWithImage_convertColorSpace(newImage, false));
+      var imageData;
+      if (MSApplicationMetadata.metadata().appVersion < 47) {
+        imageData = MSImageData.alloc().initWithImage_convertColorSpace(newImage, false);
+      } else {
+        imageData = MSImageData.alloc().initWithImage(newImage);
+      }
+      fill.setImage(imageData);
       fill.setPatternFillType(1);
 
     }

--- a/CG.sketchplugin/Contents/Sketch/js/loadImage.js
+++ b/CG.sketchplugin/Contents/Sketch/js/loadImage.js
@@ -54,14 +54,20 @@ var loadImages = function(context, dataPath, groupName, pictureName){
 
 		for(var i = 0; i < selection.length; i++){
 			var layer = selection[i];
-            if([layer class] == MSShapeGroup){
-                var image = imagesCollection[i];
-				log(image)
-                var fill = layer.style().fills().firstObject();
+      if([layer class] == MSShapeGroup) {
+        var image = imagesCollection[i];
+				log(image);
+        var fill = layer.style().fills().firstObject();
 				fill.setFillType(4);
-				fill.setImage(MSImageData.alloc().initWithImage_convertColorSpace(image, false));
+				var imageData;
+				if (MSApplicationMetadata.metadata().appVersion < 47) {
+					imageData = MSImageData.alloc().initWithImage_convertColorSpace(image, false);
+				} else {
+					imageData = MSImageData.alloc().initWithImage(image);
+				}
+				fill.setImage(imageData);
 				fill.setPatternFillType(1);
-            }
+			}
 		}
 
 		if(selection.length == 0) [doc showMessage:'Select at least one vector shape'];;

--- a/CG.sketchplugin/Contents/Sketch/js/utility.js
+++ b/CG.sketchplugin/Contents/Sketch/js/utility.js
@@ -102,7 +102,13 @@ function replaceWithImages(images, context) {
 		if([layer class] == MSShapeGroup){
 			var fill = layer.style().fills().firstObject();
 			fill.setFillType(4);
-			fill.setImage(MSImageData.alloc().initWithImage_convertColorSpace(image, false));
+			var imageData;
+			if (MSApplicationMetadata.metadata().appVersion < 47) {
+				imageData = MSImageData.alloc().initWithImage_convertColorSpace(image, false);
+			} else {
+				imageData = MSImageData.alloc().initWithImage(image);
+			}
+			fill.setImage(imageData);
 			fill.setPatternFillType(1);
 		}
 	}


### PR DESCRIPTION
This is a super simple version check for initWithImage_convertColorSpace to get the plugin working again for the latest versions.  If I were more familiar with Sketch plugins I'd have made this a bit neater, but it gets it up and running.