### PR TITLE
Update Custom.js

### DIFF
--- a/CG.sketchplugin/Contents/Sketch/Images/Custom.js
+++ b/CG.sketchplugin/Contents/Sketch/Images/Custom.js
@@ -6,7 +6,7 @@
 
 
 function onRun(context){
-    var fileTypes = [NSArray arrayWithObjects:@"png", @"jpg", @"gif", @"jpeg", nil];
+    var fileTypes = [NSArray arrayWithArray:[@"png", @"jpg", @"gif", @"jpeg"]];
     var panel = [NSOpenPanel openPanel];
     var imageFileNames = [];
     [panel setCanChooseFiles:true];


### PR DESCRIPTION
[NSArray arrayWithObjects] stopped working on 10.13. This is a bug caused by CocoaScript itself. Reference on: ccgus/CocoaScript#48 . Workaround this bug by using [NSArray arrayWithArray] instead.

Fixes #175 